### PR TITLE
fix(clippy): sort_by → sort_by_key(Reverse) — unnecessary_sort_by

### DIFF
--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -141,7 +141,7 @@ pub fn rank_by_coverage(hits: HashMap<String, usize>) -> Vec<(Vec<String>, usize
             (args, count)
         })
         .collect();
-    ranked.sort_by(|a, b| b.1.cmp(&a.1));
+    ranked.sort_by_key(|b| std::cmp::Reverse(b.1));
     ranked
 }
 

--- a/src/pipeline/test_runner.rs
+++ b/src/pipeline/test_runner.rs
@@ -357,7 +357,7 @@ pub fn compute_stats(pass_results: &[PassResult]) -> StrategyStats {
         *error_map.entry(r.verdict.clone()).or_insert(0) += 1;
     }
     let mut error_distribution: Vec<(String, usize)> = error_map.into_iter().collect();
-    error_distribution.sort_by(|a, b| b.1.cmp(&a.1));
+    error_distribution.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     StrategyStats {
         total_passes: total,


### PR DESCRIPTION
CI гоняет clippy -D warnings; два преexisting убывающих sort_by в pipeline/{report,test_runner} валили сборку.