### PR TITLE
fix: which/$PATH (#44), resilience скана (#41,#2), --workers warn (#33) + node24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,7 +40,7 @@ jobs:
           - { arch: arm64,  target: aarch64-unknown-linux-musl,  upx: true }
           - { arch: arm,    target: arm-unknown-linux-musleabi,   upx: true }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cross
 
@@ -49,13 +49,13 @@ jobs:
 
       - name: Compress with UPX
         if: matrix.upx
-        uses: crazy-max/ghaction-upx@v3
+        uses: crazy-max/ghaction-upx@v4
         with:
           version: latest
           files: target/${{ matrix.target }}/release/blockcheckw
           args: --best --lzma
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: blockcheckw-linux-${{ matrix.arch }}
           path: target/${{ matrix.target }}/release/blockcheckw
@@ -74,7 +74,7 @@ jobs:
           - { arch: mipsel, target: mipsel-unknown-linux-musl,      upx: true  }
           - { arch: mips64, target: mips64-unknown-linux-muslabi64,  upx: false }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
@@ -85,13 +85,13 @@ jobs:
 
       - name: Compress with UPX
         if: matrix.upx
-        uses: crazy-max/ghaction-upx@v3
+        uses: crazy-max/ghaction-upx@v4
         with:
           version: latest
           files: target/${{ matrix.target }}/release/blockcheckw
           args: --best --lzma
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: blockcheckw-linux-${{ matrix.arch }}
           path: target/${{ matrix.target }}/release/blockcheckw
@@ -117,7 +117,7 @@ jobs:
             musl_name: riscv64-unknown-linux-musl
             linker_env: CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_LINKER
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
@@ -135,13 +135,13 @@ jobs:
 
       - name: Compress with UPX
         if: matrix.upx
-        uses: crazy-max/ghaction-upx@v3
+        uses: crazy-max/ghaction-upx@v4
         with:
           version: latest
           files: target/${{ matrix.target }}/release/blockcheckw
           args: --best --lzma
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: blockcheckw-linux-${{ matrix.arch }}
           path: target/${{ matrix.target }}/release/blockcheckw
@@ -152,7 +152,7 @@ jobs:
     needs: [release-please, build-stable, build-nightly, build-musl-cross]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: blockcheckw-*
           path: artifacts

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -387,6 +387,131 @@ pub struct CleanupInfo {
     pub stopped_service: Option<ServiceManager>,
     /// Full nft ruleset backup taken before we stopped zapret2.
     pub nft_backup: Option<String>,
+    /// Strategies found so far, so a Ctrl+C / SIGTERM mid-scan still writes them.
+    pub scan_progress: Option<ScanProgressState>,
+}
+
+// ── Scan progress (interrupt-safe result accumulator) ────────────────────────
+
+/// Sink that `run_parallel` pushes each AVAILABLE strategy's args into as it is
+/// discovered, so found strategies are never lost to an interrupt.
+pub type SuccessSink = Arc<std::sync::Mutex<Vec<Vec<String>>>>;
+
+/// Shared, signal-handler-visible view of what a scan has found so far.
+pub type ScanProgressState = Arc<std::sync::Mutex<ScanProgress>>;
+
+struct CurrentProto {
+    protocol: blockcheckw::config::Protocol,
+    found: SuccessSink,
+}
+
+/// Accumulates scan results across protocols. The signal handler reads
+/// [`snapshot`](ScanProgress::snapshot) to write a report before exiting, so an
+/// interrupt mid-protocol still persists everything found up to that point.
+pub struct ScanProgress {
+    pub domain: String,
+    pub output: Option<String>,
+    completed: Vec<blockcheckw::pipeline::report::ProtocolSummary>,
+    current: Option<CurrentProto>,
+}
+
+impl ScanProgress {
+    pub fn new(domain: String, output: Option<String>) -> ScanProgressState {
+        Arc::new(std::sync::Mutex::new(ScanProgress {
+            domain,
+            output,
+            completed: Vec::new(),
+            current: None,
+        }))
+    }
+
+    /// Start a protocol; returns the sink to hand to `run_parallel`.
+    pub fn begin_protocol(&mut self, protocol: blockcheckw::config::Protocol) -> SuccessSink {
+        let found: SuccessSink = Arc::new(std::sync::Mutex::new(Vec::new()));
+        self.current = Some(CurrentProto {
+            protocol,
+            found: found.clone(),
+        });
+        found
+    }
+
+    /// Fold the in-progress protocol into the completed set (called when it
+    /// finishes normally). Empty protocols are kept to mirror the summary shown.
+    pub fn finish_protocol(&mut self) {
+        if let Some(c) = self.current.take() {
+            let strategies = c.found.lock().unwrap().clone();
+            self.completed
+                .push(blockcheckw::pipeline::report::ProtocolSummary {
+                    protocol: c.protocol,
+                    strategies,
+                });
+        }
+    }
+
+    /// Everything found so far, including the in-progress protocol's partial
+    /// results. This is what makes an interrupted scan still produce a report.
+    pub fn snapshot(&self) -> Vec<blockcheckw::pipeline::report::ProtocolSummary> {
+        let mut out = self.completed.clone();
+        if let Some(c) = &self.current {
+            let found = c.found.lock().unwrap().clone();
+            if !found.is_empty() {
+                out.push(blockcheckw::pipeline::report::ProtocolSummary {
+                    protocol: c.protocol,
+                    strategies: found,
+                });
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod scan_progress_tests {
+    use super::ScanProgress;
+    use blockcheckw::config::Protocol;
+
+    fn args(s: &str) -> Vec<String> {
+        s.split(' ').map(String::from).collect()
+    }
+
+    #[test]
+    fn snapshot_empty_when_nothing_found() {
+        let p = ScanProgress::new("ex.com".into(), None);
+        assert!(p.lock().unwrap().snapshot().is_empty());
+    }
+
+    #[test]
+    fn snapshot_includes_completed_protocol() {
+        let p = ScanProgress::new("ex.com".into(), None);
+        {
+            let mut g = p.lock().unwrap();
+            let sink = g.begin_protocol(Protocol::HttpsTls12);
+            sink.lock().unwrap().push(args("--dpi-desync=fake"));
+            g.finish_protocol();
+        }
+        let snap = p.lock().unwrap().snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].strategies, vec![args("--dpi-desync=fake")]);
+    }
+
+    #[test]
+    fn snapshot_includes_in_progress_partial() {
+        // THE #41 bug: interrupted mid-protocol must still expose found strategies.
+        let p = ScanProgress::new("ex.com".into(), None);
+        let sink = p.lock().unwrap().begin_protocol(Protocol::HttpsTls12);
+        sink.lock().unwrap().push(args("--dpi-desync=split2"));
+        // deliberately NO finish_protocol — simulating an interrupt
+        let snap = p.lock().unwrap().snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].strategies, vec![args("--dpi-desync=split2")]);
+    }
+
+    #[test]
+    fn snapshot_skips_empty_in_progress() {
+        let p = ScanProgress::new("ex.com".into(), None);
+        let _sink = p.lock().unwrap().begin_protocol(Protocol::HttpsTls12);
+        assert!(p.lock().unwrap().snapshot().is_empty());
+    }
 }
 
 /// Create shared cleanup state and spawn signal handlers (SIGINT + SIGTERM) that will:
@@ -397,6 +522,7 @@ pub fn spawn_cleanup_handler(nft_table: &str) -> CleanupState {
         nft_table: nft_table.to_string(),
         stopped_service: None,
         nft_backup: None,
+        scan_progress: None,
     }));
 
     // Panic hook: restore zapret2 synchronously if we crash.
@@ -477,6 +603,27 @@ async fn graceful_cleanup(signal_name: &str, state: &CleanupState, exit_code: i3
 
     blockcheckw::network::via::Via::cleanup_all().await;
     let info = state.lock().await;
+
+    // Persist whatever the scan found *before* tearing anything down, so an
+    // interrupt mid-scan still leaves a report on disk (#41).
+    if let Some(progress) = &info.scan_progress {
+        let (domain, output, summary) = {
+            let p = progress.lock().unwrap();
+            (p.domain.clone(), p.output.clone(), p.snapshot())
+        };
+        if !summary.is_empty() {
+            match scan::write_scan_reports(&domain, output.as_deref(), &summary) {
+                Ok(w) => eprintln!(
+                    "  {} partial results saved: {} strategies → {}",
+                    style("OK").green().bold(),
+                    w.count,
+                    style(&w.scan_path).cyan(),
+                ),
+                Err(e) => eprintln!("  {}failed to save partial results: {e}", WARN),
+            }
+        }
+    }
+
     blockcheckw::firewall::nftables::drop_table(&info.nft_table).await;
     eprintln!(
         "  {} nft table '{}' dropped",
@@ -514,6 +661,12 @@ pub async fn set_stopped_service(state: &CleanupState, mgr: ServiceManager) {
 /// Record nft ruleset backup, so cleanup handlers can restore it.
 pub async fn set_nft_backup(state: &CleanupState, backup: Option<String>) {
     state.lock().await.nft_backup = backup;
+}
+
+/// Register the scan's result accumulator so the signal handler can write a
+/// report from whatever was found if the scan is interrupted.
+pub async fn set_scan_progress(state: &CleanupState, progress: ScanProgressState) {
+    state.lock().await.scan_progress = Some(progress);
 }
 
 /// Restart zapret2 service, then restore nft ruleset from backup. Call at graceful exit.

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -654,13 +654,29 @@ pub fn check_prerequisites(con: &blockcheckw::ui::Console) {
     }
 }
 
+/// Check whether `name` is an executable on `PATH`.
+///
+/// We walk `$PATH` ourselves instead of shelling out to the `which` command:
+/// on minimal targets (busybox / OpenWrt routers) `which` is often absent, and
+/// the spawn then fails — which previously got misreported as "not found".
 fn which(name: &str) -> bool {
-    std::process::Command::new("which")
-        .arg(name)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_ok_and(|s| s.success())
+    std::env::var_os("PATH")
+        .map(|path| which_in(name, &path))
+        .unwrap_or(false)
+}
+
+fn which_in(name: &str, path: &std::ffi::OsStr) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    std::env::split_paths(path).any(|dir| is_executable_file(&dir.join(name)))
+}
+
+fn is_executable_file(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
 }
 
 fn nft_has_queue_support() -> bool {
@@ -671,6 +687,68 @@ fn nft_has_queue_support() -> bool {
         .stderr(std::process::Stdio::null())
         .status()
         .is_ok_and(|s| s.success())
+}
+
+#[cfg(test)]
+mod which_tests {
+    use super::which_in;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+
+    fn tmp_dir(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("bcw_which_{tag}_{nanos}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_file(dir: &Path, name: &str, mode: u32) {
+        let p = dir.join(name);
+        fs::write(&p, b"#!/bin/sh\n").unwrap();
+        fs::set_permissions(&p, fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[test]
+    fn finds_executable_in_path() {
+        let dir = tmp_dir("found");
+        write_file(&dir, "faketool", 0o755);
+        let path = OsString::from(&dir);
+        assert!(which_in("faketool", &path));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn missing_binary_returns_false() {
+        let dir = tmp_dir("missing");
+        let path = OsString::from(&dir);
+        assert!(!which_in("nope_not_here", &path));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn non_executable_file_returns_false() {
+        let dir = tmp_dir("nonexec");
+        write_file(&dir, "plain", 0o644);
+        let path = OsString::from(&dir);
+        assert!(!which_in("plain", &path));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn searches_multiple_path_entries() {
+        let a = tmp_dir("multi_a");
+        let b = tmp_dir("multi_b");
+        write_file(&b, "tool", 0o755);
+        let path = std::env::join_paths([&a, &b]).unwrap();
+        assert!(which_in("tool", &path));
+        fs::remove_dir_all(&a).ok();
+        fs::remove_dir_all(&b).ok();
+    }
 }
 
 /// Generate a local-time prefix for report filenames: "2026-03-20_18-30"

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -18,7 +18,7 @@ use tracing::{info_span, Instrument};
 
 use super::{
     chrono_local_prefix, handle_bypass_conflicts, resolve_bypass_conflicts_if_any, restore_service,
-    set_nft_backup, set_stopped_service, spawn_cleanup_handler,
+    set_nft_backup, set_scan_progress, set_stopped_service, spawn_cleanup_handler, ScanProgress,
 };
 
 pub struct ScanParams<'a> {
@@ -60,6 +60,11 @@ pub async fn run_scan(params: ScanParams<'_>) {
     });
 
     let cleanup = spawn_cleanup_handler(&config.nft_table);
+
+    // Result accumulator visible to the signal handler — found strategies survive
+    // a Ctrl+C / SIGTERM / timeout mid-scan (#41).
+    let progress = ScanProgress::new(domain.to_string(), output.map(String::from));
+    set_scan_progress(&cleanup, progress.clone()).await;
 
     let mut screen = ui::Console::new();
 
@@ -250,6 +255,9 @@ pub async fn run_scan(params: ScanParams<'_>) {
                 success = tracing::field::Empty,
                 failed = tracing::field::Empty,
             );
+            // Hand the sink to run_parallel so each AVAILABLE strategy is captured
+            // the instant it is found, not only at the end of the protocol.
+            let sink = progress.lock().unwrap().begin_protocol(protocol);
             let (results, stats) = run_parallel(RunParams {
                 config: &config,
                 domain,
@@ -260,6 +268,7 @@ pub async fn run_scan(params: ScanParams<'_>) {
                 external_pb: Some(screen.pb()),
                 mode: HttpTestMode::Standard,
                 deadline: None,
+                success_sink: Some(sink),
             })
             .instrument(proto_span.clone())
             .await;
@@ -288,6 +297,8 @@ pub async fn run_scan(params: ScanParams<'_>) {
                 protocol,
                 strategies: working,
             });
+            // Fold this protocol into the interrupt-safe accumulator.
+            progress.lock().unwrap().finish_protocol();
         }
     };
 
@@ -295,6 +306,9 @@ pub async fn run_scan(params: ScanParams<'_>) {
         let deadline = std::time::Duration::from_secs(timeout_secs);
         if tokio::time::timeout(deadline, scan_future).await.is_err() {
             timed_out = true;
+            // scan_future was cancelled mid-protocol — recover everything found so
+            // far, including the in-progress protocol's partial results (#41).
+            summary = progress.lock().unwrap().snapshot();
             nftables::drop_table(&config.nft_table).await;
             screen.newline();
             screen.println(&format!(
@@ -444,4 +458,35 @@ fn write_report(path: &str, content: &str) -> std::io::Result<()> {
     std::fs::write(path, content)?;
     blockcheckw::system::elevate::chown_to_caller(path);
     Ok(())
+}
+
+/// Paths and count produced by [`write_scan_reports`].
+pub(crate) struct WrittenReports {
+    pub scan_path: String,
+    pub count: usize,
+}
+
+/// Write the scan artifacts (optional strategies file, vanilla report, scan JSON)
+/// from a summary. Used by the signal handler to persist partial results on
+/// interrupt; the normal path (steps 5–7 above) keeps its own richer printing.
+pub(crate) fn write_scan_reports(
+    domain: &str,
+    output: Option<&str>,
+    summary: &[ProtocolSummary],
+) -> std::io::Result<WrittenReports> {
+    let now = chrono_local_prefix();
+
+    if let Some(path) = output {
+        let (content, _) = report::build_strategies_file(domain, summary);
+        write_report(path, &content)?;
+    }
+
+    let (content, _) = report::build_vanilla_report(domain, summary);
+    write_report(&format!("{now}_report_vanilla.txt"), &content)?;
+
+    let (content, count) = report::build_scan_report(domain, summary);
+    let scan_path = format!("{now}_scan.json");
+    write_report(&scan_path, &content)?;
+
+    Ok(WrittenReports { scan_path, count })
 }

--- a/src/cmd/universal.rs
+++ b/src/cmd/universal.rs
@@ -166,6 +166,7 @@ pub async fn run_universal(
                 external_pb: Some(screen.pb()),
                 mode: HttpTestMode::Standard,
                 deadline: None,
+                success_sink: None,
             })
             .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,15 @@ async fn main() {
     blockcheckw::system::elevate::tune_tcp();
     blockcheckw::system::elevate::raise_nofile_limit();
 
+    // `--workers` is global, but `check` verifies strategies sequentially by design —
+    // warn (once, post-elevation) so users don't expect it to change `check` throughput (#33).
+    if is_explicit(&matches, "workers") && matches!(cli.command, Some(Command::Check { .. })) {
+        eprintln!(
+            "{}--workers has no effect on `check` (it verifies strategies sequentially by design)",
+            blockcheckw::ui::WARN,
+        );
+    }
+
     // Pre-read stdin for check in pipe mode (before acquiring lock,
     // so the upstream pipe command can finish and release its lock first)
     let stdin_data = {

--- a/src/pipeline/benchmark.rs
+++ b/src/pipeline/benchmark.rs
@@ -388,6 +388,7 @@ pub async fn run_benchmark(
             external_pb: None,
             mode: HttpTestMode::Standard,
             deadline: Some(deadline),
+            success_sink: None,
         })
         .await;
 

--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -16,6 +16,7 @@ use crate::pipeline::test_report;
 // ── Scan report building ─────────────────────────────────────────────────────
 
 /// Intermediate per-protocol scan results (I/O-free data).
+#[derive(Clone)]
 pub struct ProtocolSummary {
     pub protocol: Protocol,
     pub strategies: Vec<Vec<String>>,

--- a/src/pipeline/runner.rs
+++ b/src/pipeline/runner.rs
@@ -50,6 +50,9 @@ pub struct RunParams<'a> {
     pub external_pb: Option<&'a ProgressBar>,
     pub mode: HttpTestMode,
     pub deadline: Option<Instant>,
+    /// Optional sink that each AVAILABLE strategy's args are pushed into as soon
+    /// as it is found, so an interrupt mid-run never loses results.
+    pub success_sink: Option<Arc<std::sync::Mutex<Vec<Vec<String>>>>>,
 }
 
 /// Run strategies in parallel batches using worker slots.
@@ -68,6 +71,7 @@ pub async fn run_parallel(params: RunParams<'_>) -> (Vec<StrategyResult>, RunSta
         external_pb,
         mode,
         deadline,
+        success_sink,
     } = params;
 
     let start = Instant::now();
@@ -189,7 +193,13 @@ pub async fn run_parallel(params: RunParams<'_>) -> (Vec<StrategyResult>, RunSta
             match join_result {
                 Ok((strategy_args, task_result)) => {
                     match &task_result {
-                        TaskResult::Success { .. } => successes += 1,
+                        TaskResult::Success { .. } => {
+                            successes += 1;
+                            // Persist the win immediately so an interrupt can't lose it.
+                            if let Some(sink) = &success_sink {
+                                sink.lock().unwrap().push(strategy_args.clone());
+                            }
+                        }
                         TaskResult::Failed { .. } => failures += 1,
                         TaskResult::Error { .. } => errors += 1,
                     }

--- a/src/pipeline/verify.rs
+++ b/src/pipeline/verify.rs
@@ -201,6 +201,7 @@ pub async fn run_verification(
             external_pb: Some(screen.pb()),
             mode: HttpTestMode::Standard,
             deadline: None,
+            success_sink: None,
         })
         .await;
 
@@ -273,6 +274,7 @@ pub async fn run_verification(
                 min_bytes: dt_config.min_bytes,
             },
             deadline: None,
+            success_sink: None,
         })
         .await;
 

--- a/tests/parallel_benchmark.rs
+++ b/tests/parallel_benchmark.rs
@@ -101,6 +101,7 @@ async fn parallel_scaling_bench() {
             external_pb: None,
             mode: HttpTestMode::Standard,
             deadline: None,
+            success_sink: None,
         })
         .await;
 


### PR DESCRIPTION
Пакет фиксов к v1.0.0 (milestone v1.0.0) + подготовка release-пайплайна.

## Фиксы
- **which по $PATH** — обход `$PATH` в Rust вместо внешней `which`; на busybox/OpenWrt её часто нет, отсюда ложное «nft not found». Closes #44
- **Resilience скана** — найденные стратегии больше не теряются при `Ctrl+C` / `SIGTERM` / таймауте: `run_parallel` пушит успехи в sink по ходу, `graceful_cleanup` и timeout-путь пишут отчёт из накопленного. Closes #41, Closes #2
- **`--workers` в check** — предупреждение, что флаг не влияет на `check` (последовательная верификация by design). Closes #33

## CI
- Бамп GitHub Actions на `node24`: `checkout@v6`, `upload-artifact@v7`, `download-artifact@v8`, `ghaction-upx@v4` — до депрекации Node 20 (16.06.2026).

## Проверка
- `cargo fmt --check`, `clippy` (default + `--features otel`) — чисто.
- `cargo test --lib --bins --features otel` — 138 + 10 зелёных.
- Кросс-сборка riscv64 (build-std) воспроизведена локально.
