### PR TITLE
fix: восстановить сборку main — проброс blocked в write_scan_reports (#49)

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -427,6 +427,7 @@ struct CurrentProto {
 pub struct ScanProgress {
     pub domain: String,
     pub output: Option<String>,
+    blocked: Vec<blockcheckw::config::Protocol>,
     completed: Vec<blockcheckw::pipeline::report::ProtocolSummary>,
     current: Option<CurrentProto>,
 }
@@ -436,9 +437,16 @@ impl ScanProgress {
         Arc::new(std::sync::Mutex::new(ScanProgress {
             domain,
             output,
+            blocked: Vec::new(),
             completed: Vec::new(),
             current: None,
         }))
+    }
+
+    /// Record the blocked protocols detected at baseline, so an interrupted
+    /// scan persists the same `blocked` list as a completed run (#49).
+    pub fn set_blocked(&mut self, blocked: Vec<blockcheckw::config::Protocol>) {
+        self.blocked = blocked;
     }
 
     /// Start a protocol; returns the sink to hand to `run_parallel`.
@@ -623,12 +631,17 @@ async fn graceful_cleanup(signal_name: &str, state: &CleanupState, exit_code: i3
     // Persist whatever the scan found *before* tearing anything down, so an
     // interrupt mid-scan still leaves a report on disk (#41).
     if let Some(progress) = &info.scan_progress {
-        let (domain, output, summary) = {
+        let (domain, output, blocked, summary) = {
             let p = progress.lock().unwrap();
-            (p.domain.clone(), p.output.clone(), p.snapshot())
+            (
+                p.domain.clone(),
+                p.output.clone(),
+                p.blocked.clone(),
+                p.snapshot(),
+            )
         };
         if !summary.is_empty() {
-            match scan::write_scan_reports(&domain, output.as_deref(), &summary) {
+            match scan::write_scan_reports(&domain, output.as_deref(), &blocked, &summary) {
                 Ok(w) => eprintln!(
                     "  {} partial results saved: {} strategies → {}",
                     style("OK").green().bold(),

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -201,6 +201,11 @@ pub async fn run_scan(params: ScanParams<'_>) {
         return;
     }
 
+    progress
+        .lock()
+        .unwrap()
+        .set_blocked(blocked_protocols.clone());
+
     let blocked_names: Vec<String> = blocked_protocols.iter().map(|p| p.to_string()).collect();
     screen.newline();
     screen.println(&ui::blocked_list(&blocked_names.join(", ")));
@@ -478,6 +483,7 @@ pub(crate) struct WrittenReports {
 pub(crate) fn write_scan_reports(
     domain: &str,
     output: Option<&str>,
+    blocked: &[blockcheckw::config::Protocol],
     summary: &[ProtocolSummary],
 ) -> std::io::Result<WrittenReports> {
     let now = chrono_local_prefix();
@@ -490,7 +496,7 @@ pub(crate) fn write_scan_reports(
     let (content, _) = report::build_vanilla_report(domain, summary);
     write_report(&format!("{now}_report_vanilla.txt"), &content)?;
 
-    let (content, count) = report::build_scan_report(domain, summary);
+    let (content, count) = report::build_scan_report(domain, blocked, summary);
     let scan_path = format!("{now}_scan.json");
     write_report(&scan_path, &content)?;
 


### PR DESCRIPTION
PR #49 добавил параметр `blocked: &[Protocol]` в `build_scan_report`, но пропустил вызов в signal-handler пути