### PR TITLE
fix: завершать nfqws2 при прерывании через Ctrl+C

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -570,6 +570,7 @@ pub fn spawn_cleanup_handler(nft_table: &str) -> CleanupState {
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         // Best-effort synchronous cleanup
+        blockcheckw::system::process::start_kill_all_background_processes();
         blockcheckw::network::via::Via::cleanup_sync();
         if let Ok(guard) = panic_state.try_lock() {
             // Drop our nft table
@@ -621,6 +622,7 @@ pub fn spawn_cleanup_handler(nft_table: &str) -> CleanupState {
             tokio::spawn(async {
                 if tokio::signal::ctrl_c().await.is_ok() {
                     eprintln!("\n  force quit");
+                    blockcheckw::system::process::kill_all_background_processes().await;
                     std::process::exit(137);
                 }
             });
@@ -633,6 +635,10 @@ pub fn spawn_cleanup_handler(nft_table: &str) -> CleanupState {
 
 /// Shared graceful cleanup logic for SIGINT and SIGTERM.
 async fn graceful_cleanup(signal_name: &str, state: &CleanupState, exit_code: i32) {
+    // Make shutdown atomic with BackgroundProcess::spawn. No worker may start a
+    // new nfqws2 after this point.
+    blockcheckw::system::process::begin_background_shutdown();
+
     eprintln!(
         "\n{}",
         style(format!("=== {signal_name} — cleaning up ==="))
@@ -683,6 +689,9 @@ async fn graceful_cleanup(signal_name: &str, state: &CleanupState, exit_code: i3
         style("OK").green().bold(),
         info.nft_table,
     );
+    // With queue rules gone, explicitly kill and reap every child we spawned.
+    // process::exit below skips destructors, so kill_on_drop alone is not enough.
+    blockcheckw::system::process::kill_all_background_processes().await;
     if let Some(ref mgr) = info.stopped_service {
         if start_service(mgr).await {
             eprintln!(

--- a/src/system/process.rs
+++ b/src/system/process.rs
@@ -1,5 +1,7 @@
+use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
 use std::time::Duration;
 use tokio::process::Command;
+use tokio::sync::Mutex;
 use tokio::time::timeout;
 
 use crate::error::BlockcheckError;
@@ -86,9 +88,48 @@ pub async fn run_process_stdin(
     })
 }
 
-/// A background process handle. Wraps a tokio::process::Child.
+#[derive(Default)]
+struct BackgroundRegistry {
+    shutting_down: bool,
+    children: Vec<Weak<Mutex<tokio::process::Child>>>,
+}
+
+fn background_registry() -> &'static StdMutex<BackgroundRegistry> {
+    static REGISTRY: OnceLock<StdMutex<BackgroundRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| StdMutex::new(BackgroundRegistry::default()))
+}
+
+/// Prevent new background children from being spawned during shutdown.
+pub fn begin_background_shutdown() {
+    background_registry().lock().unwrap().shutting_down = true;
+}
+
+fn registered_children() -> Vec<Arc<Mutex<tokio::process::Child>>> {
+    let mut registry = background_registry().lock().unwrap();
+    registry.shutting_down = true;
+    registry.children.retain(|child| child.strong_count() > 0);
+    registry.children.iter().filter_map(Weak::upgrade).collect()
+}
+
+/// Kill and reap every live child spawned through [`BackgroundProcess`].
+pub async fn kill_all_background_processes() {
+    for child in registered_children() {
+        let _ = child.lock().await.kill().await;
+    }
+}
+
+/// Best-effort synchronous kill initiation for panic hooks.
+pub fn start_kill_all_background_processes() {
+    for child in registered_children() {
+        if let Ok(mut child) = child.try_lock() {
+            let _ = child.start_kill();
+        }
+    }
+}
+
+/// A registered background process handle. Wraps a tokio process child.
 pub struct BackgroundProcess {
-    child: tokio::process::Child,
+    child: Arc<Mutex<tokio::process::Child>>,
 }
 
 impl BackgroundProcess {
@@ -100,6 +141,16 @@ impl BackgroundProcess {
                     reason: "empty command".to_string(),
                 })?;
 
+        // Holding the registry lock across spawn makes registration atomic with
+        // begin_background_shutdown(): cleanup cannot miss a concurrently
+        // created child, and no child can start after shutdown begins.
+        let mut registry = background_registry().lock().unwrap();
+        if registry.shutting_down {
+            return Err(BlockcheckError::ProcessSpawn {
+                reason: "shutdown in progress".to_string(),
+            });
+        }
+
         let child = Command::new(program)
             .args(cmd_args)
             .stdout(std::process::Stdio::null())
@@ -110,18 +161,22 @@ impl BackgroundProcess {
                 reason: e.to_string(),
             })?;
 
+        let child = Arc::new(Mutex::new(child));
+        registry.children.retain(|child| child.strong_count() > 0);
+        registry.children.push(Arc::downgrade(&child));
+
         Ok(Self { child })
     }
 
     /// Kill the process (SIGKILL) and wait to reap the zombie.
     pub async fn kill(&mut self) {
         // best-effort — process may have already exited
-        let _ = self.child.kill().await;
+        let _ = self.child.lock().await.kill().await;
     }
 
     /// Check if the process is still running.
-    pub fn try_wait(&mut self) -> Option<i32> {
-        match self.child.try_wait() {
+    pub async fn try_wait(&mut self) -> Option<i32> {
+        match self.child.lock().await.try_wait() {
             Ok(Some(status)) => Some(status.code().unwrap_or(-1)),
             _ => None,
         }
@@ -131,9 +186,28 @@ impl BackgroundProcess {
     /// Returns `Ok(())` if alive after delay, `Err(exit_code)` if it exited early.
     pub async fn wait_for_ready(&mut self, delay_ms: u64) -> Result<(), i32> {
         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-        match self.try_wait() {
+        match self.try_wait().await {
             Some(code) => Err(code),
             None => Ok(()),
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn shutdown_kills_registered_children_and_blocks_new_spawns() {
+        let mut process = BackgroundProcess::spawn(&["sleep", "30"]).expect("spawn sleep");
+        assert!(process.try_wait().await.is_none());
+
+        kill_all_background_processes().await;
+
+        assert!(process.try_wait().await.is_some());
+        let error = BackgroundProcess::spawn(&["sleep", "30"])
+            .err()
+            .expect("spawn during shutdown must fail");
+        assert!(error.to_string().contains("shutdown in progress"));
     }
 }

--- a/tests/e2e_infra.rs
+++ b/tests/e2e_infra.rs
@@ -163,7 +163,7 @@ async fn nfqws2_receives_marked_traffic() {
     let mut nfqws2 = start_nfqws2(&config, slot.qnum, &strategy).expect("start nfqws2");
     tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     assert!(
-        nfqws2.try_wait().is_none(),
+        nfqws2.try_wait().await.is_none(),
         "nfqws2 should still be running"
     );
 
@@ -179,7 +179,7 @@ async fn nfqws2_receives_marked_traffic() {
     .await;
 
     assert!(
-        nfqws2.try_wait().is_none(),
+        nfqws2.try_wait().await.is_none(),
         "nfqws2 should still be running after processing traffic"
     );
 
@@ -238,7 +238,7 @@ async fn autottl_prenat_captures_synack() {
     .await;
 
     assert!(
-        nfqws2.try_wait().is_none(),
+        nfqws2.try_wait().await.is_none(),
         "nfqws2 should still be running after autottl flow"
     );
 


### PR DESCRIPTION
## Проблема

При прерывании `scan` или повторной проверки стратегий через Ctrl+C один или несколько запущенных `nfqws2` могли остаться работать после завершения `blockcheckw`.

Оставшийся процесс становился orphan с `PPid=1`. После восстановления `zapret2` одновременно работали:

- штатный `nfqws2` от `zapret2` с `--qnum=300 --fwmark=0x40000000`;
- оставшийся worker от `blockcheckw` с `--qnum=200 --fwmark=0x10000000`.

Это могло приводить к конфликтам при последующих запусках и оставляло роутер в некорректном состоянии.

## Как проблема была обнаружена

Проблема проявилась после запуска:

```sh
/opt/zapret_files/blockcheckw -w 48 scan \
  -d instagram.com \
  -p tls12,tls13 \
  --dns doh \
  -o /tmp/gh_assets_scan.json
```

После обнаружения примерно 200 стратегий была запущена их дополнительная проверка. Во время проверки пользователь нажал Ctrl+C, после чего в памяти остался процесс `nfqws2`.

Наличие процессов до и после проверялось командой:

```sh
ps w | grep -E 'nfqws2|nfqws|tpws|zapret' | grep -v grep
```

Проблема была воспроизведена на OpenWrt 24.10.1 с `blockcheckw v0.9.1`.

Для детерминированного воспроизведения HTTP-запрос worker-задачи был искусственно задержан nftables-правилом. После отправки SIGINT `blockcheckw` завершался, но его `nfqws2` продолжал работать:

```text
nfqws2 --uid=65534:65534 --qnum=200 --fwmark=0x10000000 ...
```

Одновременно `zapret2` уже запускал свой штатный процесс:

```text
nfqws2 --user=daemon --qnum=300 --fwmark=0x40000000 ...
```

На быстрых запросах ошибка проявляется не всегда, поскольку worker может успеть пройти штатный cleanup до завершения основного процесса. Поэтому проблема зависит от тайминга.

## Причина

Обработчик первого Ctrl+C вызывает `graceful_cleanup()`, который:

1. удаляет nft-таблицу;
2. восстанавливает `zapret2`;
3. вызывает `std::process::exit(130)`.

Рабочие задачи в этот момент могут продолжать выполнять HTTP-запрос и владеть `BackgroundProcess` с запущенным `nfqws2`.

Для дочернего процесса установлено:

```rust
kill_on_drop(true)
```

Однако `std::process::exit()` немедленно завершает процесс и не запускает деструкторы Rust. Поэтому `BackgroundProcess` не уничтожается, `kill_on_drop` не срабатывает, а дочерний `nfqws2` становится orphan-процессом.

Аналогичная проблема существовала для второго Ctrl+C: принудительный `exit(137)` также мог завершить `blockcheckw` без остановки дочерних процессов.

## Что исправлено

Добавлен внутренний реестр всех процессов, запущенных через `BackgroundProcess`.

Реестр хранит handles именно собственных дочерних процессов `blockcheckw`. Внешние `pgrep`, `pkill` и поиск процессов по имени не используются, поэтому штатный `nfqws2` от `zapret2` не затрагивается.

При начале shutdown теперь выполняется следующий порядок:

1. Атомарно устанавливается состояние shutdown.
2. Новые `BackgroundProcess` больше не могут запускаться.
3. Удаляется nft-таблица blockcheckw, чтобы пакеты больше не направлялись в NFQUEUE.
4. Для каждого зарегистрированного дочернего процесса явно вызывается `child.kill().await`.
5. Tokio дожидается завершения и reap дочернего процесса.
6. После этого восстанавливается `zapret2`.
7. Только затем допускается завершение `blockcheckw`.

Регистрация процесса и проверка состояния shutdown выполняются под одной блокировкой. Это закрывает гонку, при которой новый `nfqws2` мог быть запущен одновременно с началом cleanup и не попасть в снимок зарегистрированных процессов.

Исправление применяется централизованно к `BackgroundProcess`, поэтому покрывает все команды и pipeline, запускающие `nfqws2`, включая:

- `scan`;
- `check`;
- дополнительную проверку стратегий;
- `universal`;
- остальные существующие и будущие вызовы `BackgroundProcess`.

Для второго Ctrl+C перед `exit(137)` также выполняется явный kill и reap всех зарегистрированных процессов.

В panic hook добавлено синхронное best-effort инициирование завершения дочерних процессов.

## Тесты

Добавлен unit-тест, который проверяет:

- регистрацию фонового дочернего процесса;
- его принудительное завершение во время shutdown;
- ожидание завершения процесса;
- запрет запуска новых фоновых процессов после начала shutdown.

Результаты локальных проверок:

```text
cargo fmt --check
OK

cargo clippy --all-targets -- -D warnings
OK

cargo clippy --features otel -- -D warnings
OK

cargo test --lib
161 passed; 0 failed

cargo test --lib --bins --features otel
161 passed; 0 failed
```

## Проверка на роутере

Исправленный бинарник был проверен на OpenWrt 24.10.1.

### Один SIGINT

Перед Ctrl+C присутствовал worker blockcheckw:

```text
nfqws2 --qnum=200 --fwmark=0x10000000 ...
```

После завершения blockcheckw worker отсутствовал. Остался только штатный процесс zapret2:

```text
nfqws2 --qnum=300 --fwmark=0x40000000 ...
```

### Два SIGINT

Также проверен принудительный сценарий с повторным Ctrl+C и `exit(137)`.

После завершения:

- orphan-процессов `nfqws2` от blockcheckw нет;
- штатный `zapret2` работает;
- nftables восстановлен;
- временных таблиц и правил blockcheckw не осталось.
