### PR TITLE
Унифицирован формат timestamp в check

### DIFF
--- a/src/pipeline/check.rs
+++ b/src/pipeline/check.rs
@@ -371,18 +371,7 @@ fn extract_redirect_location(headers: &str) -> String {
 }
 
 fn timestamp_iso() -> String {
-    use std::process::Command;
-    let output = Command::new("date").arg("--iso-8601=seconds").output();
-    match output {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
-        _ => {
-            let secs = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            format!("{secs}")
-        }
-    }
+    crate::pipeline::test_report::chrono_like_timestamp()
 }
 
 #[cfg(test)]
@@ -407,6 +396,15 @@ mod tests {
             0.0
         };
         assert_eq!(speed, 0.0);
+    }
+
+    #[test]
+    fn timestamp_is_utc_iso_8601() {
+        let timestamp = timestamp_iso();
+        assert_eq!(timestamp.len(), 20);
+        assert_eq!(&timestamp[10..11], "T");
+        assert!(timestamp.ends_with('Z'));
+        assert!(!timestamp[..19].chars().all(|ch| ch.is_ascii_digit()));
     }
 
     #[test]


### PR DESCRIPTION
## Что исправлено

`check` больше не вызывает внешнюю команду `date --iso-8601=seconds`. Поле `CheckReport.timestamp` формируется существующей функцией `chrono_like_timestamp()`, которая уже используется отчётами `scan` и `universal`.

## До изменения

BusyBox `date` не поддерживает GNU-опцию `--iso-8601=seconds`. На OpenWrt срабатывал fallback, возвращавший строку Unix epoch:

```json
{"timestamp":"1787390000"}
```

Формат одного JSON-поля зависел от установленной реализации `date`.

## После изменения

На GNU/Linux и BusyBox/OpenWrt используется одинаковый UTC ISO 8601 формат:

```json
{"timestamp":"2026-08-22T12:34:56Z"}
```

## Проверка

- добавлен unit-тест длины, разделителя `T`, суффикса `Z` и отсутствия чистого epoch;
- отсутствие длинной опции подтверждено на BusyBox 1.36.1 и 1.37.0;
- `cargo fmt --check`;
- `git diff --check`.
