### PR TITLE
Сохранено системное значение tcp_tw_reuse

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -357,7 +357,6 @@ async fn main() {
     });
 
     blockcheckw::system::elevate::require_root();
-    blockcheckw::system::elevate::tune_tcp();
     blockcheckw::system::elevate::raise_nofile_limit();
 
     // `--workers` is global, but `check` verifies strategies sequentially by design —

--- a/src/system/elevate.rs
+++ b/src/system/elevate.rs
@@ -48,15 +48,6 @@ pub fn require_root() {
     std::process::exit(2);
 }
 
-/// Enable tcp_tw_reuse so TIME_WAIT ports can be reused for new outgoing connections.
-/// With fwmark-based routing (no fixed port ranges), TIME_WAIT is less of an issue,
-/// but this still helps ephemeral port recycling under heavy load.
-pub fn tune_tcp() {
-    if let Err(e) = std::fs::write("/proc/sys/net/ipv4/tcp_tw_reuse", "1") {
-        tracing::warn!("failed to set tcp_tw_reuse: {e} (SELinux/AppArmor?)");
-    }
-}
-
 /// Raise RLIMIT_NOFILE so that many parallel workers don't hit "Too many open files".
 /// Each worker needs ~6-8 fd (nfqws2 process + TCP socket + nft calls).
 /// Default soft limit is often 1024 — not enough for 256+ workers.


### PR DESCRIPTION
## Что исправлено

Удалено безусловное изменение глобального sysctl `net.ipv4.tcp_tw_reuse` при запуске любой рабочей команды blockcheckw.

После перехода на fwmark-маршрутизацию фиксированные диапазоны исходящих портов не используются, поэтому глобальный тюнинг не обязателен для корректной работы. Удаление записи безопаснее, чем восстановление во множестве обычных, signal, panic и `process::exit` путей.

## До изменения

`tune_tcp()` выполнялся сразу после повышения прав и до проверки конфликтов:

```text
до запуска:  2
после abort: 1
```

Исходное значение администратора не сохранялось и не восстанавливалось. Изменение затрагивало даже `status` и запуск, отменённый до сканирования.

## После изменения

blockcheckw не читает и не изменяет `net.ipv4.tcp_tw_reuse`. Значение остаётся тем, которое настроил администратор, при нормальном завершении, раннем abort, Ctrl+C и panic.

Повышение лимита открытых файлов сохранено без изменений.

## Проверка

- подтверждено отсутствие оставшихся ссылок на `tune_tcp` и `tcp_tw_reuse` в `src`;
- `cargo fmt --check`;
- `git diff --check`;
- исходное значение `2` подтверждено на OpenWrt 23.05.5 и в функциональном воспроизведении на OpenWrt 25.12.4.
