### PR TITLE
Исправлен выбор MIPS-архитектуры в установщике

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,7 +40,17 @@ detect_arch() {
         armv7*|armv6*|arm*)     echo "arm"      ;;
         mips64*)                echo "mips64"   ;;
         mipsel*|mipsle*)        echo "mipsel"   ;;
-        mips*)                  echo "mips"     ;;
+        mips*)
+            command -v dd >/dev/null 2>&1 ||
+                die "Не удалось определить byte order MIPS: нужен dd"
+            elf_data=$(dd if=/proc/self/exe bs=1 skip=5 count=1 2>/dev/null) ||
+                die "Не удалось прочитать ELF-заголовок /proc/self/exe"
+            case "$elf_data" in
+                "$(printf '\001')") echo "mipsel" ;;
+                "$(printf '\002')") echo "mips"   ;;
+                *) die "Не удалось определить byte order MIPS по ELF-заголовку" ;;
+            esac
+            ;;
         ppc|powerpc)            echo "ppc"      ;;
         riscv64*)               echo "riscv64"  ;;
         *)  die "Неизвестная архитектура: $machine. Поддерживаются: x86_64, x86, arm64, arm, mips, mipsel, mips64, ppc, riscv64" ;;


### PR DESCRIPTION
## Что исправлено

Для неоднозначного результата `uname -m = mips` установщик теперь читает байт `EI_DATA` из ELF-заголовка `/proc/self/exe` средствами BusyBox `dd`:

- `EI_DATA=1` выбирает артефакт `mipsel`;
- `EI_DATA=2` выбирает артефакт `mips`;
- неизвестное значение завершает установку с понятной ошибкой.

Однозначные варианты `mipsel` и `mipsle` остались без изменений.

## Где проверено

- исходный код `v0.9.3` (`c317faa`);
- сценарии с подменёнными `uname=mips` и `EI_DATA=1/2`;
- синтаксис `scripts/install.sh` проверен через POSIX shell;
- полная проверка выполняется Linux CI проекта.

## Как было до исправления

Для любого значения `uname -m`, начинающегося с `mips`, выбирался big-endian архив `blockcheckw-linux-mips.tar.gz`. На little-endian устройствах, где ядро сообщает просто `mips`, установленный ELF не запускался.

## Как стало после исправления

Установщик различает byte order самой системы до скачивания архива и выбирает соответствующий опубликованный артефакт.