### PR TITLE
Добавлена совместимая с BusyBox проверка SHA256

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,7 +94,10 @@ download "${BASE_URL}/SHA256SUMS.txt" "${TMPDIR}/SHA256SUMS.txt" || \
 
 info "Проверяю SHA256..."
 cd "$TMPDIR"
-grep "$TARBALL" SHA256SUMS.txt | sha256sum -c --quiet - || \
+checksum_line=$(grep -F "  $TARBALL" SHA256SUMS.txt | head -n 1)
+[ -n "$checksum_line" ] || \
+    die "В SHA256SUMS.txt нет контрольной суммы для ${TARBALL}"
+printf '%s\n' "$checksum_line" | sha256sum -c - >/dev/null 2>&1 || \
     die "Контрольная сумма не совпала! Файл мог быть повреждён при скачивании."
 
 # --- Установка ---


### PR DESCRIPTION
## Что исправлено

Проверка загруженного архива больше не передаёт BusyBox `sha256sum` неподдерживаемую GNU-опцию `--quiet`.

Строка нужного артефакта выбирается по фиксированному имени, отдельно проверяется её наличие, после чего передаётся в стандартный режим `sha256sum -c -`.

## Где проверено

- BusyBox 1.36.1: подтверждено отсутствие `sha256sum --quiet` и успешная работа `sha256sum -c -`;
- проверены корректная сумма, несовпадение суммы и отсутствие записи нужного архива;
- синтаксис `scripts/install.sh` проверен через POSIX shell;
- полная проверка выполняется Linux CI проекта.

## Как было до исправления

Команда

```sh
grep "$TARBALL" SHA256SUMS.txt | sha256sum -c --quiet -
```

завершалась на стандартном BusyBox с ошибкой разбора `--quiet`. Установщик сообщал о повреждённом архиве, хотя checksum фактически не сравнивался.

## Как стало после исправления

Корректный архив проходит проверку на BusyBox без GNU coreutils. Повреждённый архив и отсутствующая строка checksum по-прежнему останавливают установку до распаковки и получают отдельные понятные сообщения.